### PR TITLE
Remove IS_CHANGED that causes re-execution

### DIFF
--- a/sdxl_utility.py
+++ b/sdxl_utility.py
@@ -57,10 +57,6 @@ class PromptGenerator:
         self.rng = random.Random(seed)
 
     @classmethod
-    def IS_CHANGED(cls):
-        return float("NaN")
-
-    @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {


### PR DESCRIPTION
The IS_CHANGED implementation causes the node's output to always be seen as different, so if you're setting up a workflow, tuning post-prompt-generation nodes will result in a lot of unnecessary re-execution of the workflow (and node using the output, which often is most of the workflow).