### PR TITLE
Remove directory change

### DIFF
--- a/sdxl_utility.py
+++ b/sdxl_utility.py
@@ -4,11 +4,6 @@ import json
 
 import os
 
-# Get the directory of the current script
-script_directory = os.path.dirname(__file__)
-# Change the working directory to the script directory
-os.chdir(script_directory)
-
 
 # Function to load data from a JSON file
 def load_json_file(file_name):


### PR DESCRIPTION
Changing the directory makes it so ComfyUI manager's restart functionality fails (e.g. after installing a custom node or updating in ComfyUI manager), as the process is no longer running in the base ComfyUI directory.

Removing this doesn't affect any functionality, as far as I can tell - it seems likely the directory changing was a vestige of an earlier method of loading the data files.